### PR TITLE
Fix pdf generation

### DIFF
--- a/lib/rtex/framework/rails.rb
+++ b/lib/rtex/framework/rails.rb
@@ -42,8 +42,7 @@ module RTeX
                 :disposition => (options[:disposition] rescue nil) || 'inline',
                 :url_based_filename => true,
                 :filename => (options[:filename] rescue nil),
-                :type => "application/pdf",
-                :length => File.size(serve_file.path)
+                :type => "application/pdf"
               serve_file.close
             end
           else

--- a/lib/rtex/framework/rails.rb
+++ b/lib/rtex/framework/rails.rb
@@ -31,7 +31,7 @@ module RTeX
         end
         
         def render_with_rtex(options=nil, *args, &block)
-          result = render_without_rtex(options, *args, &block)
+          result = render_without_rtex(options, *args, &block)[0]
           if result.is_a?(String) && Thread.current[:_rendering_rtex]
             Thread.current[:_rendering_rtex] = false
             options ||= {}


### PR DESCRIPTION
- The problem was that 

```
result = render_without_rtex(options, *args, &block)
```

 is string in ruby 1.8.7 but in ruby 2.2 is an array with one string - the content for pdf
